### PR TITLE
Darwin build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 node_modules
+
+# Mac
+.DS_Store
+
+# Local .npmrc preferences
+.npmrc
+
+# Built packages
+dist

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const fs = require('fs');
+const gulp = require('gulp');
+const packager = require('electron-packager');
+
+const config = JSON.parse(fs.readFileSync('package.json'));
+const appVersion = config.version;
+const electronVersion = config.devDependencies['electron-prebuilt'].match(/[\d.]+/)[0];
+const options = {
+	asar: true,
+	dir: '.',
+	icon: './img/markdownify.icns',
+	name: 'Markdownify',
+	out: 'dist',
+	overwrite: true,
+	prune: true,
+	version: electronVersion,
+	'app-version': appVersion
+};
+
+gulp.task('build:osx', (done) => {
+	options.arch = 'x64';
+	options.platform = 'darwin';
+	options['app-bundle-id'] = 'com.amitmerchant.markdownify';
+	options['helper-bundle-id'] = 'com.amitmerchant.markdownify.helper';
+	
+	packager(options, (err, paths) => {
+		if (err) {
+			console.error(err);
+		}
+		
+		done();
+	});
+});
+
+gulp.task('build:linux', () => {
+	// @TODO 
+});
+
+gulp.task('build:windows', () => {
+	// @TODO 
+});
+
+gulp.task('build', ['build:osx', 'build:linux', 'build:windows']);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "productName": "Markdownify",
   "scripts": {
-    "start": "electron main.js"
+    "start": "electron main.js",
+    "build": "rm -rf dist && gulp build"
   },
   "repository": {
     "type": "git",
@@ -35,7 +36,9 @@
   },
   "devDependencies": {
     "devtron": "^1.1.2",
-    "electron-prebuilt": "^0.36.0"
+    "electron-packager": "^7.0.3",
+    "electron-prebuilt": "^0.36.12",
+    "gulp": "^3.9.1"
   },
   "dependencies": {
     "electron-editor-context-menu": "^1.1.1",


### PR DESCRIPTION
<img width="413" alt="screen shot 2016-06-04 at 1 01 37 am" src="https://cloud.githubusercontent.com/assets/144225/15798520/12c870c6-29f0-11e6-8133-b381f1b7fae2.png">

This PR adds:
- Gulp task for osx
- Gulp stub tasks for windows and linux

And an npm script:
- `npm run build` - delete the previously created `dist` folder, and create it again with built apps inside

Make sure you run `npm install` after merging. :)

Resolves #9 
