### PR TITLE
Fix issue with emoji's inline code

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -51,6 +51,9 @@ $(() => {
     // get value right from instance
     //yourTextarea.value = cMirror.getValue();
     var markdownText = cMirror.getValue();
+    
+    // Convert emoji's
+    markdownText = replaceWithEmojis(markdownText);
     latexText = katex.renderLaTeX(markdownText);
 
     marked.setOptions({
@@ -70,7 +73,7 @@ $(() => {
               smartypants: false
             });
 
-    markdownArea.innerHTML = replaceWithEmojis(html);
+    markdownArea.innerHTML = html;
 
     //Md -> HTML
     converter = new showdown.Converter();

--- a/js/emoji.js
+++ b/js/emoji.js
@@ -883,7 +883,7 @@ const EMOJI = [
     'zzz',
 ];
 
-const REGEX_EMOJI = /:(\w+):/g;
+const REGEX_EMOJI = /\\`|`(?:\\`|[^`])*`|:(\w+):/g;
 
 this.replacer = function(match, name){
   if (EMOJI.indexOf(name) > -1) {


### PR DESCRIPTION
I realized that emoji's inside inline code were being replaced, as seen in the Atom's [CONTRIBUTING.md](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#git-commit-messages).   
The issue was pretty easily fixed using a bit more tedious regex and modifying when the  `replaceWithEmojis()` function is called.  
Feel free to let me know if there are any changes you'd like me to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/amitmerchant1990/electron-markdownify/22)
<!-- Reviewable:end -->
