### PR TITLE
Fix: Implement URL validation to block harmful schemes like javascript:

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -62,6 +62,23 @@ $(() => {
             }
         });
 
+        // Validating the harmful urls
+        const renderer = new marked.Renderer();
+
+        renderer.link = function(href, title, text) {
+        
+            // block dangerous protocols
+            if (!href || /^(javascript|data|vbscript):/i.test(href.trim())) {
+                href = "#";
+            }
+        
+            return `<a href="${href}">${text}</a>`;
+        };
+        
+        marked.setOptions({
+            renderer: renderer
+        });
+
         //Md -> Preview
         html = marked(latexText, {
             gfm: true,


### PR DESCRIPTION
Fix for issue #44 

# Description
This PR adds validation for URLs to prevent the use of harmful schemes such as javascript:.
Previously, URLs like javascript:alert`1` could bypass validation and potentially lead to remote code execution.

# Changes
- Blocked `javascript:`  , `data:text/html`  , `vbscript` URLs